### PR TITLE
Windows build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
+# this policy is requred before the project() call to allow the CMAKE_MSVC_RUNTIME_LIBRARY variable to work.
+cmake_policy(SET "CMP0091" NEW)
+
 project(guc VERSION 0.1.1)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -11,11 +14,11 @@ find_package(USD REQUIRED HINTS ${USD_ROOT} NAMES pxr)
 
 # Find MaterialX library provided by the USD installation.
 # Since we use UsdMtlx, using a custom MaterialX version leads to conflicts.
-find_package(MaterialX REQUIRED)
+find_package(MaterialX REQUIRED HINTS ${USD_ROOT})
 
 # We need to open PNG and JPEG files in order to read the number of channels
 # for shading node creation. OIIO should be provided by the USD installation.
-find_package(OpenImageIO REQUIRED)
+find_package(OpenImageIO REQUIRED HINTS ${USD_ROOT})
 
 option(GUC_BUILD_EXECUTABLE "Build the guc executable." ON)
 

--- a/cmake/UsdDefaults.cmake
+++ b/cmake/UsdDefaults.cmake
@@ -122,6 +122,13 @@ if(MSVC)
   # Enable multiprocessor builds.
   set(_GUC_CXX_FLAGS "${_GUC_CXX_FLAGS} /MP")
   set(_GUC_CXX_FLAGS "${_GUC_CXX_FLAGS} /Gm-")
+
+  # Disable boost auto-link, it creates errors when building Guc in Debug
+  # against a release Boost. And we don't have to link against it anyway on Windows.
+  _add_define("BOOST_ALL_NO_LIB")
+
+  # Same as for TBB...
+  _add_define("__TBB_NO_IMPLICIT_LINKAGE")
 else()
   # Enable all warnings.
   set(_GUC_CXX_FLAGS "${_GUC_CXX_FLAGS} -Wall -Wformat-security")


### PR DESCRIPTION
Hello,

I'm not sure if you're open to pull requests, but here I am :p
I'm wanted to use Guc to produce test USD assets from Polyhaven, but I had a few issues on Windows, so I thought I would contribute the fixes I did. If you have any comment, I'm happy to update the pull request (code convention, naming or whatever)

So basically there are 3 changes: 
- first one is in CMake: find_package wasn't finding OpenImageIO and MaterialX because USD_ROOT wasn't passed as a HINT. Now all libs are found from the USD root dir if they were built there, and still CMake will fallback to its default mechanisms if you're not using the libs from USD. I also had to change the library type to STATIC on Windows because libguc and MikkTSpace don't export any symbols (MSVC doesn't export symbols by default, contrary to Unix compilers) It's the easiest way (the other would be to explicitly export symbols, using the infamous __declspec(dllexport) macros)
- second one in CMake also: I added an option to force CMake to use the release MSVC runtime in Debug. This is because I only build USD in release, and without this I can't link against it. I also had to disable Boost and TBB's auto link features that try to be smart, but fail, and generate compile time errors in the scenario.
- third one is the last commit, and this one I'm not entirely sure: the latest release of USD (v22.05b) uses a version of MaterialX which doesn't have the `mx::Node::addInputsFromNodeDef` method. My guess is that you're using the `dev` branch of USD which might have bumped the MaterialX version. So in this "fix" I just copied the implementation from MaterialX as a free function (fortunately it's just a helper that only use other public methods) but maybe this commit can be ignored if you don't want to bother with older USD releases.

Sorry for the lengthy message, don't hesitate to tell me if there's anything I can do (especially the last commit: I can remove it if you prefer to use the dev branch and future v22.xx versions of USD)